### PR TITLE
Try OpenGL versions one by one to find the best fit one

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeEarlyConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeEarlyConfig.java
@@ -3,6 +3,10 @@ package net.minecraftforge.common;
 
 public class ForgeEarlyConfig {
 
+    public static int OPENGL_VERSION_MAJOR = 4;
+    public static int OPENGL_VERSION_MINOR = 6;
+    public static boolean OPENGL_COMPAT_PROFILE = true;
+
     public static boolean RAW_INPUT = true;
 
     //TODO : make CATEGORY?

--- a/src/main/java/net/minecraftforge/common/config/Config.java
+++ b/src/main/java/net/minecraftforge/common/config/Config.java
@@ -1,0 +1,17 @@
+package net.minecraftforge.common.config;
+
+public @interface Config {
+    public static enum Type {
+        INSTANCE(true);
+
+        private boolean isStatic = true;
+
+        private Type(boolean isStatic) {
+            this.isStatic = isStatic;
+        }
+
+        public boolean isStatic() {
+            return this.isStatic;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -1,0 +1,5 @@
+package net.minecraftforge.common.config;
+
+public class ConfigManager {
+    public static void sync(String modid, Config.Type type){}
+}

--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -23,6 +23,7 @@ import java.nio.IntBuffer;
 import java.util.*;
 
 import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.glfw.GLFW.glfwWindowHint;
 import static org.lwjgl.system.MemoryUtil.NULL;
 
 public class Display {
@@ -161,6 +162,9 @@ public class Display {
             glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, versionMajor);
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, versionMinor);
+            if (versionMajor > 3 || (versionMajor == 3 && versionMinor >= 2)) {
+                glfwWindowHint(GLFW_OPENGL_PROFILE, ForgeEarlyConfig.OPENGL_COMPAT_PROFILE ? GLFW_OPENGL_COMPAT_PROFILE : GLFW_OPENGL_CORE_PROFILE);
+            }
 
             glfwWindowHint(GLFW_MAXIMIZED, ForgeEarlyConfig.WINDOW_START_MAXIMIZED ? GLFW_TRUE : GLFW_FALSE);
             glfwWindowHint(GLFW_FOCUSED, ForgeEarlyConfig.WINDOW_START_FOCUSED ? GLFW_TRUE : GLFW_FALSE);
@@ -178,7 +182,6 @@ public class Display {
             glfwWindowHint(GLFW_SRGB_CAPABLE, ForgeEarlyConfig.OPENGL_SRGB_CONTEXT ? GLFW_TRUE : GLFW_FALSE);
             glfwWindowHint(GLFW_DOUBLEBUFFER, ForgeEarlyConfig.OPENGL_DOUBLEBUFFER ? GLFW_TRUE : GLFW_FALSE);
             glfwWindowHint(GLFW_CONTEXT_NO_ERROR, ForgeEarlyConfig.OPENGL_CONTEXT_NO_ERROR ? GLFW_TRUE : GLFW_FALSE);
-            glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, ForgeEarlyConfig.OPENGL_DEBUG_CONTEXT ? GLFW_TRUE : GLFW_FALSE);
             glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, ForgeEarlyConfig.OPENGL_DEBUG_CONTEXT ? GLFW_TRUE : GLFW_FALSE);
             glfwWindowHint(GLFW_DECORATED, ForgeEarlyConfig.DECORATED ? GLFW_TRUE : GLFW_FALSE);
 


### PR DESCRIPTION
I implemented a method that iterates through OpenGL versions to find the one that successfully creates a context (like 4.6 -> 4.5 -> ... -> 2.1; I set minimum requirement to GL2.1)

The initial version and profile preference are read from the config values, and I added 3 more entries to `ForgeEarlyConfig` to guide the process.
```
public static int OPENGL_VERSION_MAJOR = 4;
public static int OPENGL_VERSION_MINOR = 6;
public static boolean OPENGL_COMPAT_PROFILE = true;
```
I'll pr these config changes to Cleanroom as well.

I can't find a way to test my implementation thoroughly btw, but it should work as intended.

