### PR TITLE
Add support for old glDebugMessageCallback

### DIFF
--- a/src/main/java/org/lwjglx/opengl/GL43.java
+++ b/src/main/java/org/lwjglx/opengl/GL43.java
@@ -298,9 +298,9 @@ public class GL43 {
     }
 
     public static void glDebugMessageCallback(KHRDebugCallback callback) {
-        long userParam = callback == null ? 0 : CallbackUtil.createGlobalRef(callback.getHandler());
-        CallbackUtil.registerContextCallbackKHR(userParam);
-        org.lwjgl.opengl.GL43.nglDebugMessageCallback(callback == null ? 0 : callback.getPointer(), userParam);
+        org.lwjgl.opengl.GL43.glDebugMessageCallback((source, type, id, severity, length, message, userParam) -> {
+            callback.getHandler().handleMessage(source, type, id, severity, org.lwjgl.opengl.GLDebugMessageCallback.getMessage(length, message));
+        }, 0);
     }
 
     public static void glDebugMessageControl(int source, int type, int severity, java.nio.IntBuffer ids,


### PR DESCRIPTION
`CallbackUtil` is not implemented (yet?) and thus using the old `glDebugMessageCallback` will just disable debug message callbacks.
This PR fixes the issue by creating a `GLDebugMessageCallbackI` using the `KHRDebugCallback` which doesn't require the use of `CallbackUtil`.