### PR TITLE
Fix cursor position on HiDPi displays

### DIFF
--- a/src/main/java/org/lwjglx/input/Mouse.java
+++ b/src/main/java/org/lwjglx/input/Mouse.java
@@ -288,8 +288,8 @@ public class Mouse {
         }
         // convert back from framebuffer coordinates to screen-space coordinates
         float inv_scale = 1.0f / Display.getPixelScaleFactor();
-        new_x *= (int) inv_scale;
-        new_y *= (int) inv_scale;
+        new_x = (int) (new_x * inv_scale);
+        new_y = (int) (new_y * inv_scale);
         GLFW.glfwSetCursorPos(Display.getWindow(), new_x, new_y);
         // this might lose accuracy, since we just went from fb->screen and this will
         // undo that change. Yay floating point numbers!


### PR DESCRIPTION
This PR fixes the issue where the cursor warps to the left-top corner instead of the center of the window, when `COCOA_RETINA_FRAMEBUFFER=true` and on a HiDPi display.

Steps to reproduce on Wayland:

- Install latest Cleanroom, go to `forge_early.cfg` and set `COCOA_RETINA_FRAMEBUFFER=true` and `FORCE_WAYLAND=true`
- Set the monitor display scale to anything bigger than 100%
- Launch the game, join a world and observe that the cursor warps to the **left-top corner** of the window
- With this PR, the cursor should correctly warp to the **center** of the window

Explanation: when the display scale is, say, 150%, `Display#getPixelScaleFactor` would return 1.5, and `inv_scale` (see diff) would be `1.0f / 1.5f`. When subsequently casting it to `int`, it becomes `0`, thus both `new_x` and `new_y` becoming `0`. This PR fixes this by making sure `inv_scale` is not cast to `int` before multiplication.