### PR TITLE
Fix Cmd+<key> shortcuts don't work on macOS

### DIFF
--- a/src/main/java/org/lwjglx/opengl/Display.java
+++ b/src/main/java/org/lwjglx/opengl/Display.java
@@ -3,6 +3,7 @@ package org.lwjglx.opengl;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.ForgeEarlyConfig;
 import net.minecraftforge.common.config.ConfigManager;
+import org.lwjgl.system.Platform;
 import org.lwjglx.LWJGLException;
 import org.lwjglx.input.*;
 import org.lwjglx.util.Rectangle;
@@ -358,7 +359,13 @@ public class Display {
                     }
 
 
-                    if ((GLFW_MOD_CONTROL & mods) != 0 && !ctrlGraphicalMode) { // Handle ctrl + x/c/v.
+                    if ((GLFW_MOD_SUPER & mods) != 0) {
+                        Keyboard.addGlfwKeyEvent(window, key, scancode, action, mods, (char) key);
+                        if (Platform.get() != Platform.MACOSX) {
+                            // MacOS doesn't send a char event for Cmd+KEY presses, but other platforms do.
+                            cancelNextChar = true;
+                        }
+                    } else if ((GLFW_MOD_CONTROL & mods) != 0 && !ctrlGraphicalMode) { // Handle ctrl + x/c/v.
                         Keyboard.addGlfwKeyEvent(window, key, scancode, action, mods, (char) (key & 0x1f));
                         cancelNextChar = true; // Cancel char event from ctrl key since its already handled here
                     } else if (action > 0) { // Delay press and repeat key event to actual char input. There is ALWAYS a


### PR DESCRIPTION
Fixes https://github.com/CleanroomMC/Cleanroom/issues/404

Implementation is based on https://github.com/GTNewHorizons/lwjgl3ify/pull/79
Tested on macOS (Apple M4) and Windows (the existing behavior is unchanged)